### PR TITLE
Show category titles, move h2 out of lowerMain HTML

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -34,12 +34,12 @@
             <div class='error' id='error'></div>
           </form>
         </section>
+      </section>
 
         <h2 id='pageTitle'></h2>
 
         <section class='random-recipes' id='randomRecipes'>
         </section>
-      </section>
 
       <section class='single-recipe-view hidden' id='singleRecipe'>
       </section>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -171,6 +171,7 @@ function displayCategoryRecipes(event) {
   const category = event.target.id;
   repository.filterByTag(category);
   displayRecipes();
+  pageTitle.innerHTML = `${category}`
 }
 
 function displaySearchedRecipes(event) {
@@ -244,6 +245,7 @@ function navigateToHome() {
   hidePageArea(singleRecipeArea);
   hidePageArea(instructionsArea);
   hidePageArea(ingredientsArea);
+  hidePageArea(recipeByCat);
   showPageArea(lowerMain);
   showPageArea(pageTitle)
   showPageArea(randomRecArea);


### PR DESCRIPTION
PR Template:

Is this a fix or a feature?
- [x] Bug fix
- [ ] Feature
- [ ] Refactor

Describe the feature - fix - refactor:
moved h2 out of lowerMain section, added innerHTML to category search function scripts.js

How was this tested?
- [ ] open index.html
- [x] localhost
- [ ] terminal

Where should the reviewer start - test:
index.html and scripts.js 

Additional comments:
